### PR TITLE
Feat: info channel

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,11 +18,11 @@ var rootCmd = &cobra.Command{
 		log := logrus.New()
 
 		config := &discordhobbyist.Config{
-			GuildID:       os.Getenv("GUILD_ID"),
-			BotToken:      os.Getenv("BOT_TOKEN"),
-			AppID:         os.Getenv("APP_ID"),
-			InfoChannelID: os.Getenv("INFO_CHANNEL_ID"),
-			HTTPAddr:      os.Getenv("HTTP_ADDR"),
+			GuildID:        os.Getenv("GUILD_ID"),
+			BotToken:       os.Getenv("BOT_TOKEN"),
+			AppID:          os.Getenv("APP_ID"),
+			InfoChannelKey: os.Getenv("INFO_CHANNEL_KEY"),
+			HTTPAddr:       os.Getenv("HTTP_ADDR"),
 		}
 
 		hobbyist := discordhobbyist.NewDiscordBot(log, config)

--- a/pkg/discordhobbyist/config.go
+++ b/pkg/discordhobbyist/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	BotToken string
 	AppID    string
 
-	InfoChannelID string
+	InfoChannelKey string
 
 	HTTPAddr string
 }
@@ -25,8 +25,8 @@ func (c *Config) Validate() error {
 		return errors.New("app id is required")
 	}
 
-	if c.InfoChannelID == "" {
-		return errors.New("info channel id is required")
+	if c.InfoChannelKey == "" {
+		return errors.New("info channel key is required")
 	}
 
 	if c.HTTPAddr == "" {


### PR DESCRIPTION
Sends some messages to a debug/info channel in the Discord server. Usually things that would have to be found in logs since they aren't really acceptable to be exposed via HTTP.